### PR TITLE
Fix Handler.run not throwing

### DIFF
--- a/smtpclient/src/main/java/ch/heig/dai/lab/smtp/Client.java
+++ b/smtpclient/src/main/java/ch/heig/dai/lab/smtp/Client.java
@@ -78,7 +78,6 @@ public class Client {
         final String SERVER_ADDRESS = "localhost";
 
         try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
-            // FIXME: I'm not sure this is caught properly.
             for (Mail mail : mails) {
                 executor.execute(new Handler(new Socket(SERVER_ADDRESS, SERVER_SOCKET), new Worker(mail)));
             }

--- a/smtpclient/src/main/java/ch/heig/dai/lab/smtp/Handler.java
+++ b/smtpclient/src/main/java/ch/heig/dai/lab/smtp/Handler.java
@@ -42,7 +42,7 @@ public class Handler implements Runnable {
             out.flush();
          }
       } catch (Exception e) {
-         System.out.println("Error: " + e);
+         System.err.println("Error: " + e.getMessage());
          System.exit(1);
       }
    }


### PR DESCRIPTION
In the end, it was too time consuming to implement shared exception handling between the `ExecutorService` and the runnable handlers. 

Handler exceptions handling will stay within the class itself but now prints to standard error.